### PR TITLE
fix: fix Thorchain driver issues

### DIFF
--- a/drivers/thorchain.js
+++ b/drivers/thorchain.js
@@ -15,14 +15,14 @@ class Thorchain extends Driver {
     const pools = await request('https://midgard.thorchain.info/v2/pools?status=available');
 
     return pools.map((pool) => {
-      const [, base, baseReference] = pool.asset.split(/[.-]/);
+      const [base, baseReference] = pool.asset.split('-');
 
       return new Ticker({
         base,
         baseReference,
         quote: 'RUNE',
         close: pool.assetPrice,
-        quoteVolume: pool.volume24h,
+        quoteVolume: pool.volume24h / (10 ** 8),
       });
     });
   }


### PR DESCRIPTION
The blockchain is now left into the base because there
were multiple tickers with the same base (ETH) and we
need to be able to differentiate between them. Also
the quote volume was way too high compared to
https://app.thorswap.finance/, probably because of
decimals, which has been fixed by scaling the volume
down accordingly.