### PR TITLE
fix: circleci namespace is deprecated in favor of cimg. We need a new…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:16.13
+    - image: cimg/node:20.8
 
 version: 2.1
 orbs:


### PR DESCRIPTION
…er node version